### PR TITLE
Change to reading access key from environment variable

### DIFF
--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1634397430127</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -3,5 +3,6 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
 org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=1.7

--- a/etc/access_keys.properties.sample
+++ b/etc/access_keys.properties.sample
@@ -1,4 +1,0 @@
-# Rename this to `access_keys.properties` and insert
-# the access keys necessary to access any services used
-# in this lab.
-fixer_io=

--- a/src/xrate/ExchangeRateReader.java
+++ b/src/xrate/ExchangeRateReader.java
@@ -37,33 +37,22 @@ public class ExchangeRateReader {
     }
 
     /**
-     * This reads the `fixer_io` access key from `etc/access_keys.properties`
-     * and assigns it to the field `accessKey`.
+     * This reads the `fixer_io` access key from from the system
+     * environment and assigns it to the field `accessKey`.
      *
-     * @throws IOException if there is a problem reading the properties file
+     * @throws some sort of exception if we fail to find the
+     *          expected environment variable
      */
-    private void readAccessKeys() throws IOException {
-        Properties properties = new Properties();
-        FileInputStream in = null;
-        try {
-            // Don't change this filename unless you know what you're doing.
-            // It's crucial that we don't commit the file that contains the
-            // (private) access keys. This file is listed in `.gitignore` so
-            // it's safe to put keys there as we won't accidentally commit them.
-            in = new FileInputStream("etc/access_keys.properties");
-        } catch (FileNotFoundException e) {
-            /*
-             * If this error gets generated, make sure that you have the desired
-             * properties file in your project's `etc` directory. You may need
-             * to rename the file ending in `.sample` by removing that suffix.
-             */
-            System.err.println("Couldn't open etc/access_keys.properties; have you renamed the sample file?");
-            throw(e);
+    private void readAccessKeys() {
+        // Read the desired environment variable.
+        String accessKey = System.getenv("fixer_io_access_key");
+        // If that environment variable isn't defined, then
+        // `getenv()` returns `null`. We'll throw a (custom)
+        // exception if that happens since the program can't
+        // really run if we don't have an access key.
+        if (accessKey == null) {
+            throw new MissingAccessKeyException();
         }
-        properties.load(in);
-        // This assumes we're using Fixer.io and that the desired access key is
-        // in the properties file in the key labelled `fixer_io`.
-        accessKey = properties.getProperty("fixer_io");
     }
 
     /**

--- a/src/xrate/MissingAccessKeyException.java
+++ b/src/xrate/MissingAccessKeyException.java
@@ -1,0 +1,33 @@
+package xrate;
+
+/**
+ * A custom exception class that we'll throw if an attempt to
+ * read a API access key from the system environment fails.
+ * 
+ * This basically just has all the "standard" exception
+ * constructors, calling "super()" to ensure that the relevant
+ * constructor in RuntimeException is also called.
+ */
+public class MissingAccessKeyException extends RuntimeException {
+
+    public MissingAccessKeyException() {
+    }
+
+    public MissingAccessKeyException(String message) {
+        super(message);
+    }
+
+    public MissingAccessKeyException(Throwable cause) {
+        super(cause);
+    }
+
+    public MissingAccessKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MissingAccessKeyException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}


### PR DESCRIPTION
This changes from reading the Fixer.io API access key from a properties file to reading it from a system environment variable.

That considerably simplifies the code in interesting ways, but I did decide to create a custom exception to throw if the environment variable isn't properly defined. I'm hoping that might help with debugging environment variable problems, especially in GitHub Actions.